### PR TITLE
WIP/Help please: add VTXv4 file format support

### DIFF
--- a/filemonitor.cpp
+++ b/filemonitor.cpp
@@ -77,12 +77,16 @@ void FileMonitor::run()
         // Load the filenames into a list
         while ((dirp = readdir(dp)) != NULL)
         {
-            // Select only pages that might be teletext. tti or ttix at the moment.
+            // Select only pages that might be teletext. .tti, .ttix or .vtx at the moment.
             // strcasestr doesn't seem to be in my Windows compiler.
             #ifdef _WIN32
             char* p=strstr(dirp->d_name,".tti");
+	    if (!p)
+                p=strstr(dirp->d_name,".vtx");
             #else
             char* p=strcasestr(dirp->d_name,".tti");
+	    if (!p)
+                p=strcasestr(dirp->d_name,".vtx");
             #endif
             // std::cerr << path << "/" << dirp->d_name << std::endl;
             if (p)

--- a/ttxpage.h
+++ b/ttxpage.h
@@ -264,6 +264,13 @@ class TTXPage
         std::string m_FormatPageNumber(TTXPage* p); /// \return the page number ready to write to file
         int findPageNumber(char* buf);
         bool m_Loaded;
+
+        /** Load a VTXv$ page
+         * \param filename : The source file
+         * \return true if the page was loaded
+         */
+        bool m_LoadVTXv4(std::string filename);
+
         /** Load an EP1 page
          * \param filename : The source file
          * \return true if the page was loaded


### PR DESCRIPTION
VTXv4 is used by the [dvbtext](https://github.com/girst/ttxd/tree/master/src/dvbtext-src) tool, which fetches pages from live DVB-{T,S,C} teletext.

hi, I've implemented rudimentary support for a format I've got thousands of teletext pages for. There are some problems I've yet to overcome, these are:

 * how does Setm_SubPage work? each file contains only 1 subpage; they are differentiated by their file name (PPP_SS.vtx)
 * how do i need to pad the very first line? mine is only 32 chars wide (left pad? right pad?)
 * black-on-white text is missing (probably an issue with not setting text colour?)
 * my pages are in german; all the umlauts are displayed wrongly. where/how can I set which language the pages are in?

I'd love to get some help with this, if you've got time, @peterkvt80. I can privately share with you my teletext archive, if you need to. Thanks!