### PR TITLE
Make sure dependencies for raspi-teletext are present

### DIFF
--- a/getvbit2
+++ b/getvbit2
@@ -17,7 +17,7 @@ if (( $(lsb_release -r | tr -dc '0-9') > 11 )); then
     fi
 else
     # install required packages to compile raspi-teletext
-    sudo apt -y install raspberrypi-dev raspberrypi-kernel-headers
+    sudo apt -y install libraspberrypi-dev raspberrypi-kernel-headers
 
     # download the raspi-teletext git repository and compile it
     git clone https://github.com/ali1234/raspi-teletext.git $HOME/raspi-teletext

--- a/getvbit2
+++ b/getvbit2
@@ -16,6 +16,9 @@ if (( $(lsb_release -r | tr -dc '0-9') > 11 )); then
         exit 1
     fi
 else
+    # install required packages to compile raspi-teletext
+    sudo apt -y install raspberrypi-dev raspberrypi-kernel-headers
+
     # download the raspi-teletext git repository and compile it
     git clone https://github.com/ali1234/raspi-teletext.git $HOME/raspi-teletext
     cd $HOME/raspi-teletext


### PR DESCRIPTION
If someone has Raspberry Pi OS Lite installed, the necessary development packages needed for raspi-teletext are not installed. This makes compilation fail, but vbit2 doesn't detect the fail resulting in a broken vbit2 service. Added a step that does install these packages.